### PR TITLE
Should fix the broken build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Tokens** is a Java library for verifying and storing OAuth 2.0 service access tokens. It is resilient, configurable, and production-tested, and works with all JVM languages.
 
-[![Build Status](https://travis-ci.org/zalando-stups/tokens.svg?branch=master)](https://travis-ci.org/zalando-stups/tokens)
+[![Build Status](https://travis-ci.org/zalando/tokens.svg?branch=master)](https://travis-ci.org/zalando-stups/tokens)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/org.zalando.stups/tokens/badge.svg)](http://www.javadoc.io/doc/org.zalando.stups/tokens)
 ![Maven Central](https://img.shields.io/maven-central/v/org.zalando.stups/tokens.svg)
 [![Coverage Status](https://coveralls.io/repos/zalando-stups/tokens/badge.svg?branch=master)](https://coveralls.io/r/zalando-stups/tokens?branch=master)


### PR DESCRIPTION
It still uses the `zalando-stups` repository instead of `zalando`